### PR TITLE
Fixes Import; Adds Export All; Adds Delete All

### DIFF
--- a/Assets/settings.css
+++ b/Assets/settings.css
@@ -252,7 +252,63 @@ TABLE OF CONTENTS:
     font-weight: 600;
     padding-bottom: 0.5rem;
     border-bottom: 1px solid var(--border-color);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
+
+.section-subtitle-buttons {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+#settingsModal .mp-export-all-btn {
+    border: 1px solid var(--border-color);
+    background-color: var(--background);
+    color: var(--text);
+    padding: 0.2rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: normal;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+    #settingsModal .mp-export-all-btn:hover {
+        background-color: var(--shadow);
+    }
+
+    #settingsModal .mp-export-all-btn i {
+        font-size: 0.85em;
+    }
+
+#settingsModal .mp-delete-all-btn {
+    border: 1px solid var(--danger-color, #dc3545);
+    background-color: transparent;
+    color: var(--danger-color, #dc3545);
+    padding: 0.2rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: normal;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+    #settingsModal .mp-delete-all-btn:hover {
+        background-color: var(--danger-color, #dc3545);
+        color: white;
+    }
+
+    #settingsModal .mp-delete-all-btn i {
+        font-size: 0.85em;
+    }
 
 /* Instruction type buttons */
 #settingsModal #instructionTypeGroup {

--- a/Tabs/Text2Image/MagicPrompt.html
+++ b/Tabs/Text2Image/MagicPrompt.html
@@ -325,7 +325,17 @@
 
                                 <!-- Custom Instructions Management Section -->
                                 <div class="instruction-section">
-                                    <h6 class="section-subtitle">Custom Instructions</h6>
+                                    <h6 class="section-subtitle">
+                                        Custom Instructions
+                                        <span class="section-subtitle-buttons">
+                                            <button type="button" class="btn btn-sm mp-export-all-btn" id="exportAllInstructionsBtn" title="Export All Custom Instructions">
+                                                <i class="fas fa-download"></i> Export All
+                                            </button>
+                                            <button type="button" class="btn btn-sm mp-delete-all-btn" id="deleteAllInstructionsBtn" title="Delete All Custom Instructions">
+                                                <i class="fas fa-trash"></i> Delete All
+                                            </button>
+                                        </span>
+                                    </h6>
                                     <div id="customInstructionsList" class="custom-instructions-list">
                                         <!-- Custom instructions listed here -->
                                         <div class="text-center text-muted py-3" id="noCustomInstructionsMsg">


### PR DESCRIPTION
Fixes:

* importing a file shows the OS file picker twice due to an event handler that is triggered multiple times.
* single export wrong shape

Adds:
* handy "Delete All" button (with confirmation)
* "Export All" button

---

Currently exporting a single custom instruction generates something like:

```json
{
  "id": "custom-1761622326609",
  "title": "3D Figurine",
  "content": "CONTENT HERE",
  "tooltip": "Custom instructions for 3D Figurine",
  "categories": [
    "prompt"
  ],
  "created": "2025-10-28T03:32:06.609Z",
  "updated": "2025-10-28T03:32:06.609Z"
}
```

but the Import feature requires a structure like:

```json
{
  "custom-1761622326609": {
    "id": "custom-1761622326609",
    "title": "3D Figurine",
    "content": "CONTENT HERE",
    "tooltip": "Custom instructions for 3D Figurine",
    "categories": [
      "prompt"
    ],
    "created": "2025-10-28T03:32:06.609Z",
    "updated": "2025-10-28T03:32:06.609Z"
  }
}
```

<img width="731" height="412" alt="CleanShot 2026-01-07 at 09 09 42" src="https://github.com/user-attachments/assets/91296dbc-d911-48c6-84e4-7d25aad5eebf" />
