### PR TITLE
Adds button spacing

### DIFF
--- a/Assets/settings.css
+++ b/Assets/settings.css
@@ -215,7 +215,7 @@ TABLE OF CONTENTS:
         /* Unselected state */
         border: 1px solid var(--shadow);
         background: var(--shadow);
-        color: var(--emphasis-text);
+        color: var(--text-soft);
     }
 
     #settingsModal .btn-check:checked + .btn-outline-primary {


### PR DESCRIPTION
Adds some spacing around the instructions buttons, and fixes the text color.

Currently:

<img width="723" height="336" alt="CleanShot 2026-01-07 at 09 10 48" src="https://github.com/user-attachments/assets/33f7e348-8d42-480a-9317-62f6a41170d4" />

Now:

<img width="726" height="360" alt="CleanShot 2026-01-07 at 09 14 13" src="https://github.com/user-attachments/assets/f731b213-4106-4539-9072-7464272386cc" />

