### PR TITLE
Refactor MagicPromptExtension.cs for readability

### DIFF
--- a/InstructionResolver.cs
+++ b/InstructionResolver.cs
@@ -1,0 +1,154 @@
+using FreneticUtilities.FreneticExtensions;
+using Hartsy.Extensions.MagicPromptExtension.WebAPI;
+using Newtonsoft.Json.Linq;
+using SwarmUI.Text2Image;
+using SwarmUI.Utils;
+
+namespace Hartsy.Extensions.MagicPromptExtension;
+
+public static class InstructionResolver
+{
+    public static string Resolve(T2IParamInput userInput, string instructionId, T2IRegisteredParam<string> paramInstructions)
+    {
+        var instructionKey = GetInstructionKey(userInput, instructionId, paramInstructions);
+        var instructionsObj = GetInstructionsObject();
+
+        Logs.Debug($"MagicPromptExtension.InstructionResolver: instructionId='{instructionId ?? "(null)"}', using='{instructionKey}'");
+
+        if (instructionsObj == null)
+        {
+            return instructionKey;
+        }
+
+        if (string.IsNullOrWhiteSpace(instructionKey))
+        {
+            return GetDefaultInstruction(instructionsObj);
+        }
+
+        return TryGetCustomInstructionByKey(instructionsObj, instructionKey, userInput)
+            ?? TryGetCustomInstructionByTitle(instructionsObj, instructionKey, userInput)
+            ?? TryGetBaseInstruction(instructionsObj, instructionKey)
+            ?? GetDefaultInstruction(instructionsObj);
+    }
+
+    /// <summary>
+    /// Substitutes &lt;var:name&gt; tags in instructions with variable values from the prompt.
+    /// Variables are set in the prompt using &lt;setvar[name]:value&gt; syntax.
+    /// </summary>
+    public static string SubstituteVariables(string instructions, T2IParamInput userInput)
+    {
+        if (string.IsNullOrWhiteSpace(instructions) || !instructions.Contains("<var:"))
+        {
+            return instructions;
+        }
+
+        if (!userInput.ExtraMeta.TryGetValue("mp_variables", out object variablesObj) ||
+            variablesObj is not Dictionary<string, string> variables ||
+            variables.Count == 0)
+        {
+            return instructions;
+        }
+
+        return FreneticUtilities.FreneticToolkit.StringConversionHelper.QuickSimpleTagFiller(
+            instructions, "<", ">", tag =>
+            {
+                string prefix = tag.BeforeAndAfter(':', out string varName);
+                if (prefix.ToLowerInvariant() != "var")
+                {
+                    return $"<{tag}>";
+                }
+
+                if (variables.TryGetValue(varName, out string value))
+                {
+                    Logs.Debug($"MagicPromptExtension.InstructionResolver: substituted <var:{varName}> with \"{value}\"");
+                    return value;
+                }
+
+                Logs.Warning($"MagicPromptExtension.InstructionResolver: variable '{varName}' not found for substitution");
+                return $"<var:{varName}>";
+            }, false, 0);
+    }
+
+    private static string GetInstructionKey(T2IParamInput userInput, string instructionId, T2IRegisteredParam<string> paramInstructions)
+    {
+        return !string.IsNullOrWhiteSpace(instructionId) ? instructionId : userInput.Get(paramInstructions);
+    }
+
+    private static JToken GetInstructionsObject()
+    {
+        var sessionSettings = SessionSettings.GetMagicPromptSettings()
+            .GetAwaiter()
+            .GetResult();
+
+        if (sessionSettings?["success"]?.Value<bool>() != true)
+        {
+            return null;
+        }
+
+        return sessionSettings["settings"]?["instructions"];
+    }
+
+    private static string GetDefaultInstruction(JToken instructionsObj)
+    {
+        Logs.Debug("MagicPromptExtension.InstructionResolver: using default \"prompt\" instruction");
+        return instructionsObj["prompt"]?.ToString();
+    }
+
+    private static string TryGetCustomInstructionByKey(JToken instructionsObj, string key, T2IParamInput userInput)
+    {
+        var customContent = instructionsObj["custom"]?[key]?["content"]?.ToString();
+        if (string.IsNullOrWhiteSpace(customContent))
+        {
+            return null;
+        }
+
+        var title = instructionsObj["custom"]?[key]?["title"]?.ToString();
+        Logs.Debug($"MagicPromptExtension.InstructionResolver: using custom instruction \"{title}\" (matched by key)");
+        return SubstituteVariables(customContent, userInput);
+    }
+
+    private static string TryGetCustomInstructionByTitle(JToken instructionsObj, string titleToMatch, T2IParamInput userInput)
+    {
+        if (instructionsObj["custom"] is not JObject customObj)
+        {
+            return null;
+        }
+
+        foreach (var prop in customObj.Properties())
+        {
+            var title = prop.Value?["title"]?.ToString();
+            if (string.IsNullOrEmpty(title))
+            {
+                continue;
+            }
+
+            if (!string.Equals(title, titleToMatch, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var content = prop.Value?["content"]?.ToString();
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                continue;
+            }
+
+            Logs.Debug($"MagicPromptExtension.InstructionResolver: using custom instruction \"{title}\" (matched by title)");
+            return SubstituteVariables(content, userInput);
+        }
+
+        return null;
+    }
+
+    private static string TryGetBaseInstruction(JToken instructionsObj, string key)
+    {
+        var baseContent = instructionsObj[key]?.ToString();
+        if (string.IsNullOrWhiteSpace(baseContent))
+        {
+            return null;
+        }
+
+        Logs.Debug($"MagicPromptExtension.InstructionResolver: using base instruction \"{key}\"");
+        return baseContent;
+    }
+}

--- a/MagicPromptExtension.cs
+++ b/MagicPromptExtension.cs
@@ -2,43 +2,15 @@ using Hartsy.Extensions.MagicPromptExtension.WebAPI;
 using SwarmUI.Core;
 using SwarmUI.Utils;
 using SwarmUI.Text2Image;
-using Newtonsoft.Json.Linq;
-using SwarmUI.Accounts;
-using FreneticUtilities.FreneticExtensions;
-using System.Text.RegularExpressions;
 
 namespace Hartsy.Extensions.MagicPromptExtension;
 
+/// <summary>
+/// MagicPrompt - an LLM-powered prompt enhancement tool.
+/// </summary>
 public class MagicPromptExtension : Extension
 {
-    /// <summary>
-    /// Cache for prompt rewrite results. Key is the normalized prompt, value is the LLM response.
-    /// Limited to 1,000 entries with LRU (Least Recently Used) eviction.
-    /// </summary>
-    private static readonly Dictionary<string, string> _promptCache = new();
-    private static readonly LinkedList<string> _cacheAccessOrder = new();
-    private static readonly Dictionary<string, LinkedListNode<string>> _cacheNodes = new();
-    private const int MaxCacheSize = 1000;
-    private static readonly object CacheLock = new();
-
-    /// <summary>
-    /// Tracks pending LLM requests to prevent duplicate calls for the same normalized prompt.
-    /// Key is the normalized prompt, value is a TaskCompletionSource that completes when the LLM response is ready.
-    /// </summary>
-    private static readonly Dictionary<string, TaskCompletionSource<string>> _pendingRequests = new();
-
-    // Matches <mpprompt:...> and <mpprompt[InstructionName]:...>
-    // Group 1 = instruction identifier (optional), Group 2 = prompt content (handles nested tags)
-    private static readonly Regex MppromptRegex = new(@"<mpprompt(?:\[([^\]]+)\])?:((?:[^<>]|<[^>]*>)+)>", RegexOptions.Compiled);
-    private static readonly Regex MpresponseRegex = new(@"<mpresponse:(\d+)>", RegexOptions.Compiled);
-    private const int MaxWaitTimeMs = 30000; // 30-second timeout for waiting threads
-
-    // Cache for models/settings response to avoid duplicate API calls between GetValues lambdas
-    private static readonly object ModelsCacheLock = new();
-    private static JObject _modelsCacheResponse;
-    private static DateTime _modelsCacheTimeUtc;
-    private static readonly TimeSpan ModelsCacheTtl = TimeSpan.FromSeconds(10);
-
+    private static readonly PromptCache _promptCache = new();
     private static T2IRegisteredParam<bool> _paramUseCache;
     private static T2IRegisteredParam<string> _paramModelId;
     private static T2IRegisteredParam<string> _paramInstructions;
@@ -46,6 +18,17 @@ public class MagicPromptExtension : Extension
     public override void OnPreInit()
     {
         Logs.Info("MagicPromptExtension Version 2.4 Now with Vision and automatic processing! has started.");
+        RegisterAssets();
+    }
+
+    public override void OnInit()
+    {
+        MagicPromptAPI.Register();
+        RegisterT2IParameters();
+    }
+
+    private void RegisterAssets()
+    {
         ScriptFiles.Add("Assets/magicprompt.js");
         ScriptFiles.Add("Assets/vision.js");
         ScriptFiles.Add("Assets/chat.js");
@@ -56,40 +39,33 @@ public class MagicPromptExtension : Extension
         StyleSheetFiles.Add("Assets/settings.css");
     }
 
-    public override void OnInit()
-    {
-        // Register API endpoints so they can be used in the frontend
-        MagicPromptAPI.Register();
-        AddT2IParameters();
-    }
-
-    private static void AddT2IParameters()
+    private static void RegisterT2IParameters()
     {
         var paramGroup = new T2IParamGroup(
             Name: "Magic Prompt Auto Enable",
-            Description: "Automatically use Magic Prompt to rewrite your prompt " +
-                         "before generation.",
+            Description: "Automatically use Magic Prompt to rewrite your prompt before generation.",
             Toggles: true,
             Open: false,
             OrderPriority: 9
         );
+
         _paramUseCache = T2IParamTypes.Register<bool>(new T2IParamType(
             Name: "MP Use Cache",
-            Description: "Cache LLM results for static prompts to avoid repeated " +
-                         "requests to LLM.",
+            Description: "Cache LLM results for static prompts to avoid repeated requests to LLM.",
             Default: "true",
             Group: paramGroup,
             OrderPriority: 1
         ));
+
         T2IParamTypes.Register<bool>(new T2IParamType(
             Name: "MP Generate Wildcard Seed",
-            Description: "Every time you press Generate, a new Wildcard Seed is " +
-                         "generated. This is extremely useful for batching images, " +
-                         "so they can reuse cached LLM responses.",
+            Description: "Every time you press Generate, a new Wildcard Seed is generated. " +
+                         "This is extremely useful for batching images, so they can reuse cached LLM responses.",
             Default: "false",
             Group: paramGroup,
             OrderPriority: 2
         ));
+
         _paramModelId = T2IParamTypes.Register<string>(new T2IParamType(
             Name: "MP Model ID",
             Description: "Select an LLM to use for this batch",
@@ -98,8 +74,9 @@ public class MagicPromptExtension : Extension
             Group: paramGroup,
             OrderPriority: 3,
             ValidateValues: false,
-            GetValues: GetModelList
+            GetValues: ModelListProvider.GetModelList
         ));
+
         _paramInstructions = T2IParamTypes.Register<string>(new T2IParamType(
             Name: "MP Instructions",
             Description: "Select a prompt to use for this batch",
@@ -108,588 +85,39 @@ public class MagicPromptExtension : Extension
             Group: paramGroup,
             OrderPriority: 4,
             ValidateValues: false,
-            GetValues: GetInstructionList
+            GetValues: ModelListProvider.GetInstructionList
         ));
 
         PromptRegion.RegisterCustomPrefix("mpprompt");
         PromptRegion.RegisterCustomPrefix("mpresponse");
+        T2IPromptHandling.PromptTagPostProcessors["mpprompt"] = ProcessMppromptTag;
+        T2IPromptHandling.PromptTagPostProcessors["mpresponse"] = ProcessMpresponseTag;
+        RegisterLateParameterHandler();
+    }
 
-        T2IPromptHandling.PromptTagPostProcessors["mpprompt"] = (data, context) =>
+    private static string ProcessMppromptTag(string data, TagHandlerContext context)
+    {
+        if (context.Variables.Count > 0 && context.Input != null)
         {
-            if (context.Variables.Count > 0 && context.Input != null)
-            {
-                context.Input.ExtraMeta["mp_variables"] = new Dictionary<string, string>(context.Variables);
-            }
+            context.Input.ExtraMeta["mp_variables"] = new Dictionary<string, string>(context.Variables);
+        }
 
-            var instructionPart = !string.IsNullOrEmpty(context.PreData) ? $"[{context.PreData}]" : "";
-            var parsedData = context.Parse(data);
-            return $"<mpprompt{instructionPart}:{parsedData}>";
-        };
+        var instructionPart = !string.IsNullOrEmpty(context.PreData) ? $"[{context.PreData}]" : "";
+        var parsedData = context.Parse(data);
+        return $"<mpprompt{instructionPart}:{parsedData}>";
+    }
 
-        T2IPromptHandling.PromptTagPostProcessors["mpresponse"] = (data, context) =>
-        {
-            return $"<mpresponse:{data}>";
-        };
+    private static string ProcessMpresponseTag(string data, TagHandlerContext context)
+    {
+        return $"<mpresponse:{data}>";
+    }
 
+    private static void RegisterLateParameterHandler()
+    {
         T2IParamInput.LateSpecialParameterHandlers.Add(userInput =>
         {
-            var prompt = userInput.Get(T2IParamTypes.Prompt);
-            var modelId = userInput.Get(_paramModelId);
-            var useCache = userInput.Get(_paramUseCache);
-
-            var matches = MppromptRegex.Matches(prompt);
-
-            if (matches.Count == 0)
-            {
-                if (MpresponseRegex.IsMatch(prompt))
-                {
-                    Logs.Warning("MagicPrompt: <mpresponse> found but no mpprompt tags exist");
-                    prompt = MpresponseRegex.Replace(prompt, "");
-                }
-                ReplaceMpOriginal(prompt, "", userInput);
-                return;
-            }
-
-            if (string.IsNullOrWhiteSpace(modelId))
-            {
-                prompt = MppromptRegex.Replace(prompt, m => m.Groups[2].Value);
-                prompt = MpresponseRegex.Replace(prompt, "");
-                ReplaceMpOriginal(prompt, "", userInput);
-                return;
-            }
-
-            if (!useCache)
-            {
-                ClearCache();
-            }
-
-            var firstMppromptContent = matches[0].Groups[2].Value;
-            var llmResponses = new List<string>();
-
-            for (int i = 0; i < matches.Count; i++)
-            {
-                var match = matches[i];
-                var fullTag = match.Value;
-                var instructionId = match.Groups[1].Success ? match.Groups[1].Value : null;
-                var mppromptContent = ResolveMpresponseReferences(match.Groups[2].Value, llmResponses);
-
-                string llmResponse;
-                try
-                {
-                    llmResponse = useCache
-                        ? HandleCacheableRequest(mppromptContent, userInput, instructionId)
-                        : MakeLlmRequest(mppromptContent, userInput, instructionId);
-
-                    if (string.IsNullOrEmpty(llmResponse))
-                    {
-                        Logs.Error($"MagicPrompt: empty response from LLM for tag #{i}: {fullTag}");
-                        llmResponse = mppromptContent;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logs.Error($"MagicPrompt: LLM call failed for tag #{i} '{fullTag}': {ex.Message}");
-                    llmResponse = mppromptContent;
-                }
-
-                llmResponses.Add(llmResponse);
-                prompt = prompt.Replace(fullTag, llmResponse);
-            }
-
-            prompt = ResolveMpresponseReferences(prompt, llmResponses, logStandalone: true);
-            ReplaceMpOriginal(prompt, firstMppromptContent, userInput);
+            var handler = new PromptHandler(_promptCache, _paramUseCache, _paramModelId, _paramInstructions);
+            handler.ProcessPrompt(userInput);
         });
-    }
-
-    private static string ResolveMpresponseReferences(string text, List<string> llmResponses, bool logStandalone = false)
-    {
-        return MpresponseRegex.Replace(text, m =>
-        {
-            if (!int.TryParse(m.Groups[1].Value, out int refIndex))
-            {
-                return m.Value;
-            }
-            if (refIndex >= 0 && refIndex < llmResponses.Count)
-            {
-                return llmResponses[refIndex];
-            }
-            if (logStandalone)
-            {
-                Logs.Warning($"MagicPrompt: <mpresponse:{refIndex}> references invalid index (only {llmResponses.Count} responses available)");
-                return "";
-            }
-            Logs.Error($"MagicPrompt: <mpresponse:{refIndex}> references future mpprompt (only {llmResponses.Count} responses available)");
-            return $"[ERROR: mpresponse:{refIndex} not yet available]";
-        });
-    }
-
-    private static void ReplaceMpOriginal(string prompt, string mpprompt, T2IParamInput userInput)
-    {
-        userInput.Set(T2IParamTypes.Prompt, prompt.Replace("<mporiginal>", mpprompt));
-    }
-
-    /// <summary>
-    /// Normalizes a prompt by trimming, converting to lowercase, and removing all whitespace.
-    /// Used for cache key generation to ensure consistent matching.
-    /// </summary>
-    private static string NormalizePrompt(string prompt)
-    {
-        return string.IsNullOrWhiteSpace(prompt)
-            ? string.Empty
-            : new string(prompt.Trim().ToLowerInvariant().Where(c => !char.IsWhiteSpace(c)).ToArray());
-    }
-
-    /// <summary>
-    /// Attempts to retrieve a cached result for the given normalized prompt.
-    /// Updates LRU order if found.
-    /// </summary>
-    /// <remarks>Must be called within a lock(CacheLock) block.</remarks>
-    private static bool TryGetFromCache(string normalizedPrompt, out string cachedResult)
-    {
-        if (_promptCache.TryGetValue(normalizedPrompt, out cachedResult))
-        {
-            Logs.Debug("MagicPrompt: cache hit for static-tag prompt.");
-            // Update LRU order: move to end (most recently used)
-            if (_cacheNodes.TryGetValue(normalizedPrompt, out var node))
-            {
-                _cacheAccessOrder.Remove(node);
-                _cacheAccessOrder.AddLast(node);
-            }
-            return true;
-        }
-        return false;
-    }
-
-    /// <summary>
-    /// Signals all waiting threads that the LLM request has completed.
-    /// </summary>
-    /// <remarks>Must be called within a lock(CacheLock) block.</remarks>
-    private static void SignalPendingRequest(string normalizedPrompt, string result)
-    {
-        if (_pendingRequests.TryGetValue(normalizedPrompt, out var tcs))
-        {
-            // Always set a result (even if empty), never leave TCS pending
-            tcs.SetResult(result ?? string.Empty);
-        }
-    }
-
-    /// <summary>
-    /// Removes a pending request from tracking, typically after completion or failure.
-    /// </summary>
-    /// <remarks>Must be called within a lock(CacheLock) block.</remarks>
-    private static void CleanupPendingRequest(string normalizedPrompt)
-    {
-        _pendingRequests.Remove(normalizedPrompt);
-    }
-
-    private static string HandleCacheableRequest(string prompt, T2IParamInput userInput, string instructionId = null)
-    {
-        // Include instruction ID in cache key to differentiate requests with same prompt but different instructions
-        var cacheKey = string.IsNullOrEmpty(instructionId)
-            ? NormalizePrompt(prompt)
-            : $"{NormalizePrompt(prompt)}||{instructionId.ToLowerInvariant()}";
-
-        TaskCompletionSource<string> pendingTcs = null;
-
-        // Fast path: check if already cached
-        lock (CacheLock)
-        {
-            if (TryGetFromCache(cacheKey, out var cachedResult))
-            {
-                return cachedResult;
-            }
-
-            // Check if another thread is already fetching this prompt
-            if (_pendingRequests.TryGetValue(cacheKey, out var existingTcs))
-            {
-                Logs.Debug("MagicPrompt: another thread is already fetching this prompt, waiting for result...");
-                pendingTcs = existingTcs;
-                // Don't return yet - we need to exit the lock first!
-            }
-            else
-            {
-                // We are the OWNER - create a TaskCompletionSource for other threads to wait on
-                var tcs = new TaskCompletionSource<string>();
-                _pendingRequests[cacheKey] = tcs;
-            }
-        }
-
-        // If another thread was already fetching, wait for it OUTSIDE the lock
-        if (pendingTcs != null)
-        {
-            return WaitForPendingRequest(cacheKey, pendingTcs);
-        }
-
-        // Make LLM request OUTSIDE the lock to avoid blocking other threads
-        string llmResult;
-        try
-        {
-            llmResult = MakeLlmRequest(prompt, userInput, instructionId);
-        }
-        catch (Exception ex)
-        {
-            Logs.Error($"MagicPrompt LLM request failed: {ex.Message}");
-            
-            // Clean up the pending request so other threads can retry
-            lock (CacheLock)
-            {
-                CleanupPendingRequest(cacheKey);
-            }
-
-            return null;
-        }
-
-        // Add successful result to cache and signal waiting threads
-        lock (CacheLock)
-        {
-            // Store in cache even if null to avoid retrying failed requests
-            AddToCache(cacheKey, llmResult ?? string.Empty);
-            
-            // Signal all waiting threads with the result
-            SignalPendingRequest(cacheKey, llmResult);
-            
-            // Clean up the pending request entry
-            CleanupPendingRequest(cacheKey);
-        }
-
-        return llmResult;
-    }
-
-    /// <summary>
-    /// Waits for a pending LLM request to complete with a timeout.
-    /// This is called by non-owner threads that detected another thread is already fetching the result.
-    /// </summary>
-    private static string WaitForPendingRequest(string normalizedPrompt, TaskCompletionSource<string> tcs)
-    {
-        try
-        {
-            // Wait for the owner thread to complete the request
-            if (tcs.Task.Wait(MaxWaitTimeMs))
-            {
-                var result = tcs.Task.Result;
-                
-                // If result is empty, it means LLM request failed or returned empty
-                if (string.IsNullOrEmpty(result))
-                {
-                    Logs.Debug("MagicPrompt: waited for owner request, but got empty result");
-                    return null;
-                }
-
-                Logs.Debug($"MagicPrompt: waited {MaxWaitTimeMs}ms for owner request, got result");
-                return result;
-            }
-            else
-            {
-                Logs.Warning($"MagicPrompt: timeout after {MaxWaitTimeMs}ms waiting for owner request to complete");
-                return null;
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            Logs.Error("MagicPrompt: pending request was cancelled");
-            return null;
-        }
-        catch (Exception ex)
-        {
-            Logs.Error($"MagicPrompt: error waiting for pending request: {ex.Message}");
-            return null;
-        }
-    }
-
-    private static void AddToCache(string normalizedPrompt, string llmPrompt)
-    {
-        // Prune oldest entries if we've reached the max cache size
-        while (_promptCache.Count >= MaxCacheSize)
-        {
-            var oldestNode = _cacheAccessOrder.First;
-            if (oldestNode != null)
-            {
-                var oldestKey = oldestNode.Value;
-                _promptCache.Remove(oldestKey);
-                _cacheNodes.Remove(oldestKey);
-                _cacheAccessOrder.RemoveFirst();
-            }
-            else
-            {
-                break;
-            }
-        }
-
-        // Add or update the cache entry
-        _promptCache[normalizedPrompt] = llmPrompt;
-        
-        // Remove from access order if already exists (for update case)
-        if (_cacheNodes.TryGetValue(normalizedPrompt, out var existingNode))
-        {
-            _cacheAccessOrder.Remove(existingNode);
-        }
-        
-        // Add to the end (most recently used)
-        var newNode = _cacheAccessOrder.AddLast(normalizedPrompt);
-        _cacheNodes[normalizedPrompt] = newNode;
-    }
-
-    private static void ClearCache()
-    {
-        lock (CacheLock)
-        {
-            _promptCache.Clear();
-            _cacheAccessOrder.Clear();
-            _cacheNodes.Clear();
-
-            // Cancel any pending requests so waiting threads don't hang indefinitely
-            foreach (var tcs in _pendingRequests.Values)
-            {
-                tcs.TrySetCanceled();
-            }
-            _pendingRequests.Clear();
-        }
-    }
-
-    private static string MakeLlmRequest(string prompt, T2IParamInput userInput, string instructionId = null)
-    {
-        var request = new JObject
-        {
-            ["messageContent"] = new JObject
-            {
-                ["text"] = prompt,
-                ["instructions"] = ResolveInstructions(userInput, instructionId)
-            },
-            ["modelId"] = userInput.Get(_paramModelId, defVal: string.Empty),
-            ["messageType"] = "Text",
-            ["action"] = "prompt",
-            ["session_id"] = userInput.SourceSession?.ID ?? string.Empty,
-            ["seed"] = userInput.Get(T2IParamTypes.Seed, -1).ToString()
-        };
-
-        var resp = LLMAPICalls.MagicPromptPhoneHome(request, userInput.SourceSession)
-            .GetAwaiter()
-            .GetResult();
-
-        if (!(bool)resp?["success"])
-        {
-            return null;
-        }
-
-        var llmResponse = resp?["response"]?.ToString();
-        return string.IsNullOrWhiteSpace(llmResponse) ? null : llmResponse;
-    }
-
-    /// <summary>
-    /// Resolves the instruction content to use for an LLM request.
-    /// Priority: 1) instructionId from tag, 2) instructions parameter from UI, 3) default "prompt" instruction
-    /// </summary>
-    /// <param name="instructionId">Optional instruction identifier from the mpprompt tag (e.g., from &lt;mpprompt[Video Request]:...&gt;)</param>
-    private static string ResolveInstructions(T2IParamInput userInput, string instructionId = null)
-    {
-        // If instructionId is provided from the tag, use it; otherwise fall back to UI parameter
-        var uiInstruction = userInput.Get(_paramInstructions);
-        var instructions = !string.IsNullOrWhiteSpace(instructionId)
-            ? instructionId
-            : uiInstruction;
-
-        Logs.Debug($"MagicPrompt ResolveInstructions: instructionId='{instructionId ?? "(null)"}', uiInstruction='{uiInstruction}', using='{instructions}'");
-
-        var sessionSettings = SessionSettings.GetMagicPromptSettings()
-            .GetAwaiter()
-            .GetResult();
-        if (!sessionSettings["success"]!.Value<bool>())
-        {
-            return instructions;
-        }
-
-        var settings = sessionSettings!["settings"];
-        if (settings == null)
-        {
-            return instructions;
-        }
-
-        var instructionsObj = settings!["instructions"];
-        if (instructionsObj == null)
-        {
-            return instructions;
-        }
-
-        if (string.IsNullOrWhiteSpace(instructions))
-        {
-            return instructionsObj["prompt"]?.ToString();
-        }
-
-        // instructions currently holds the selected key (either from tag or UI)
-        // First check custom instructions by key
-        var customPrompt = instructionsObj["custom"]?[instructions]?["content"]?.ToString();
-        if (!string.IsNullOrWhiteSpace(customPrompt))
-        {
-            var title = instructionsObj["custom"][instructions]?["title"]?.ToString();
-            Logs.Debug($"MagicPrompt: using custom instructions \"{title}\"");
-            return SubstituteVariablesInInstructions(customPrompt, userInput);
-        }
-
-        // Check custom instructions by title (case-insensitive match for user convenience)
-        if (instructionsObj["custom"] is JObject customObj)
-        {
-            foreach (var prop in customObj.Properties())
-            {
-                var title = prop.Value?["title"]?.ToString();
-                if (!string.IsNullOrEmpty(title) &&
-                    string.Equals(title, instructions, StringComparison.OrdinalIgnoreCase))
-                {
-                    var content = prop.Value?["content"]?.ToString();
-                    if (!string.IsNullOrWhiteSpace(content))
-                    {
-                        Logs.Debug($"MagicPrompt: using custom instructions \"{title}\" (matched by title)");
-                        return SubstituteVariablesInInstructions(content, userInput);
-                    }
-                }
-            }
-        }
-
-        var basePrompt = instructionsObj[instructions]?.ToString();
-        if (!string.IsNullOrWhiteSpace(basePrompt))
-        {
-            Logs.Debug($"MagicPrompt: using base instructions \"{instructions}\"");
-            return basePrompt;
-        }
-
-        Logs.Debug("MagicPrompt: using base instructions \"prompt\"");
-        return instructionsObj["prompt"]?.ToString();
-    }
-
-    /// <summary>
-    /// Substitutes &lt;var:name&gt; tags in instructions with variable values from the prompt.
-    /// Variables are set in the prompt using &lt;setvar[name]:value&gt; syntax.
-    /// </summary>
-    private static string SubstituteVariablesInInstructions(string instructions, T2IParamInput userInput)
-    {
-        if (string.IsNullOrWhiteSpace(instructions) || !instructions.Contains("<var:"))
-        {
-            return instructions;
-        }
-
-        if (!userInput.ExtraMeta.TryGetValue("mp_variables", out object variablesObj) ||
-            variablesObj is not Dictionary<string, string> variables ||
-            variables.Count == 0)
-        {
-            return instructions;
-        }
-
-        var parsedInstructions = FreneticUtilities.FreneticToolkit.StringConversionHelper.QuickSimpleTagFiller(
-            instructions, "<", ">", tag =>
-            {
-                string prefix = tag.BeforeAndAfter(':', out string varName);
-                if (prefix.ToLowerInvariant() != "var")
-                {
-                    return $"<{tag}>";
-                }
-
-                if (variables.TryGetValue(varName, out string value))
-                {
-                    Logs.Debug($"MagicPrompt: substituted <var:{varName}> with \"{value}\" in instructions");
-                    return value;
-                }
-
-                Logs.Warning($"MagicPrompt: variable '{varName}' not found in prompt for instruction substitution");
-                return $"<var:{varName}>";
-            }, false, 0);
-
-        return parsedInstructions;
-    }
-
-    private static List<string> GetModelList(Session session)
-    {
-        var defaultResponse = new List<string>{"loading///loading"};
-
-        try
-        {
-            var response = GetModelsResponseCached(session);
-            if (response?["success"]?.Value<bool>() != true)
-            {
-                return defaultResponse;
-            }
-
-            var models = response["models"] as JArray;
-            if (models == null || models.Count == 0)
-            {
-                return defaultResponse;
-            }
-
-            var list = new List<string>(models.Count);
-            foreach (var m in models)
-            {
-                var modelId = m?["model"]?.ToString();
-                var name = m?["name"]?.ToString();
-                if (string.IsNullOrWhiteSpace(modelId)) continue;
-                if (string.IsNullOrWhiteSpace(name)) name = modelId;
-                list.Add($"{modelId}///{name}");
-            }
-
-            return list.Count > 0 ? list : defaultResponse;
-        }
-        catch
-        {
-            return defaultResponse;
-        }
-    }
-
-    private static List<string> GetInstructionList(Session session)
-    {
-        var defaultResponse = new List<string>{"loading///loading"};
-
-        try
-        {
-            var list = new List<string>();
-            var response = GetModelsResponseCached(session);
-            var settings = response?["settings"] as JObject;
-            var instructions = settings?["instructions"] as JObject;
-
-            var prompt = instructions?["prompt"]?.ToString();
-            if (!string.IsNullOrWhiteSpace(prompt))
-            {
-                list.Add($"prompt///Enhance Prompt (Default)");
-            }
-
-            var custom = instructions?["custom"] as JObject;
-            if (custom != null)
-            {
-                foreach (var prop in custom.Properties())
-                {
-                    var title = prop.Value?["title"]?.ToString();
-                    if (!string.IsNullOrEmpty(title))
-                    {
-                        list.Add($"{prop.Name}///{title}");
-                    }
-                }
-            }
-
-            return list.Count > 0 ? list : defaultResponse;
-        }
-        catch
-        {
-            return defaultResponse;
-        }
-    }
-
-    private static JObject GetModelsResponseCached(Session session)
-    {
-        // Serve from cache if fresh
-        lock (ModelsCacheLock)
-        {
-            if (_modelsCacheResponse != null && DateTime.UtcNow - _modelsCacheTimeUtc < ModelsCacheTtl)
-            {
-                return _modelsCacheResponse;
-            }
-        }
-
-        var resp = LLMAPICalls.GetMagicPromptModels(session)
-            .GetAwaiter()
-            .GetResult();
-
-        lock (ModelsCacheLock)
-        {
-            _modelsCacheResponse = resp;
-            _modelsCacheTimeUtc = DateTime.UtcNow;
-        }
-
-        return resp;
     }
 }

--- a/MagicPromptExtension.cs
+++ b/MagicPromptExtension.cs
@@ -95,7 +95,7 @@ public class MagicPromptExtension : Extension
         RegisterLateParameterHandler();
     }
 
-    private static string ProcessMppromptTag(string data, TagHandlerContext context)
+    private static string ProcessMppromptTag(string data, T2IPromptHandling.PromptTagContext context)
     {
         if (context.Variables.Count > 0 && context.Input != null)
         {
@@ -107,7 +107,7 @@ public class MagicPromptExtension : Extension
         return $"<mpprompt{instructionPart}:{parsedData}>";
     }
 
-    private static string ProcessMpresponseTag(string data, TagHandlerContext context)
+    private static string ProcessMpresponseTag(string data, T2IPromptHandling.PromptTagContext context)
     {
         return $"<mpresponse:{data}>";
     }

--- a/ModelListProvider.cs
+++ b/ModelListProvider.cs
@@ -1,0 +1,119 @@
+using Hartsy.Extensions.MagicPromptExtension.WebAPI;
+using Newtonsoft.Json.Linq;
+using SwarmUI.Accounts;
+
+namespace Hartsy.Extensions.MagicPromptExtension;
+
+public static class ModelListProvider
+{
+    private const string LoadingPlaceholder = "loading///loading";
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(10);
+    private static readonly object _cacheLock = new();
+    private static JObject _cachedResponse;
+    private static DateTime _cacheTimeUtc;
+
+    public static List<string> GetModelList(Session session)
+    {
+        var defaultResponse = new List<string> { LoadingPlaceholder };
+
+        try
+        {
+            var response = GetCachedResponse(session);
+            if (response?["success"]?.Value<bool>() != true)
+            {
+                return defaultResponse;
+            }
+
+            var models = response["models"] as JArray;
+            if (models == null || models.Count == 0)
+            {
+                return defaultResponse;
+            }
+
+            var list = new List<string>(models.Count);
+            foreach (var m in models)
+            {
+                var modelId = m?["model"]?.ToString();
+                if (string.IsNullOrWhiteSpace(modelId))
+                {
+                    continue;
+                }
+
+                var name = m?["name"]?.ToString();
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    name = modelId;
+                }
+
+                list.Add($"{modelId}///{name}");
+            }
+
+            return list.Count > 0 ? list : defaultResponse;
+        }
+        catch
+        {
+            return defaultResponse;
+        }
+    }
+
+    public static List<string> GetInstructionList(Session session)
+    {
+        var defaultResponse = new List<string> { LoadingPlaceholder };
+
+        try
+        {
+            var list = new List<string>();
+            var response = GetCachedResponse(session);
+            var settings = response?["settings"] as JObject;
+            var instructions = settings?["instructions"] as JObject;
+
+            var prompt = instructions?["prompt"]?.ToString();
+            if (!string.IsNullOrWhiteSpace(prompt))
+            {
+                list.Add("prompt///Enhance Prompt (Default)");
+            }
+
+            var custom = instructions?["custom"] as JObject;
+            if (custom != null)
+            {
+                foreach (var prop in custom.Properties())
+                {
+                    var title = prop.Value?["title"]?.ToString();
+                    if (!string.IsNullOrEmpty(title))
+                    {
+                        list.Add($"{prop.Name}///{title}");
+                    }
+                }
+            }
+
+            return list.Count > 0 ? list : defaultResponse;
+        }
+        catch
+        {
+            return defaultResponse;
+        }
+    }
+
+    private static JObject GetCachedResponse(Session session)
+    {
+        lock (_cacheLock)
+        {
+            if (_cachedResponse != null && DateTime.UtcNow - _cacheTimeUtc < CacheTtl)
+            {
+                return _cachedResponse;
+            }
+        }
+
+        var response = LLMAPICalls.GetMagicPromptModels(session)
+            .GetAwaiter()
+            .GetResult();
+
+        lock (_cacheLock)
+        {
+            _cachedResponse = response;
+            _cacheTimeUtc = DateTime.UtcNow;
+        }
+
+        return response;
+    }
+}

--- a/PromptCache.cs
+++ b/PromptCache.cs
@@ -1,0 +1,219 @@
+using SwarmUI.Utils;
+
+namespace Hartsy.Extensions.MagicPromptExtension;
+
+public class PromptCache
+{
+    private readonly Dictionary<string, string> _cache = new();
+    private readonly LinkedList<string> _accessOrder = new();
+    private readonly Dictionary<string, LinkedListNode<string>> _cacheNodes = new();
+    private readonly Dictionary<string, TaskCompletionSource<string>> _pendingRequests = new();
+    private readonly object _lock = new();
+
+    private readonly int _maxSize;
+    private const int DefaultTimeoutMs = 90_000;
+
+    public PromptCache(int maxSize = 1000)
+    {
+        _maxSize = maxSize;
+    }
+
+    /// <summary>
+    /// Gets a cached result or creates a new one using the provided function.
+    /// Handles request deduplication - if another thread is already fetching the same key,
+    /// this thread will wait for that result instead of making a duplicate request.
+    /// </summary>
+    public string GetOrCreate(string prompt, string instructionId, Func<string> createValue, int timeoutMs = 0)
+    {
+        var cacheKey = BuildCacheKey(prompt, instructionId);
+        var effectiveTimeout = timeoutMs > 0 ? timeoutMs : DefaultTimeoutMs;
+        TaskCompletionSource<string> pendingTcs = null;
+
+        lock (_lock)
+        {
+            if (TryGetFromCacheLocked(cacheKey, out var cachedResult))
+            {
+                return cachedResult;
+            }
+
+            if (_pendingRequests.TryGetValue(cacheKey, out var existingTcs))
+            {
+                Logs.Debug("MagicPromptExtension.PromptCache: another thread is already fetching this prompt, waiting...");
+                pendingTcs = existingTcs;
+            }
+            else
+            {
+                // We are the owner - create a TaskCompletionSource for other threads to wait on
+                var tcs = new TaskCompletionSource<string>();
+                _pendingRequests[cacheKey] = tcs;
+            }
+        }
+
+        // If another thread was already fetching, wait for it OUTSIDE the lock
+        if (pendingTcs != null)
+        {
+            return WaitForPendingRequest(pendingTcs, effectiveTimeout);
+        }
+
+        // Make the request OUTSIDE the lock to avoid blocking other threads
+        string result;
+        try
+        {
+            result = createValue();
+        }
+        catch (Exception ex)
+        {
+            Logs.Error($"MagicPromptExtension.PromptCache: factory failed: {ex.Message}");
+
+            lock (_lock)
+            {
+                CleanupPendingRequestLocked(cacheKey);
+            }
+
+            return null;
+        }
+
+        lock (_lock)
+        {
+            if (result != null)
+            {
+                AddToCacheLocked(cacheKey, result);
+            }
+
+            SignalPendingRequestLocked(cacheKey, result);
+            CleanupPendingRequestLocked(cacheKey);
+        }
+
+        return result;
+    }
+
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _cache.Clear();
+            _accessOrder.Clear();
+            _cacheNodes.Clear();
+
+            foreach (var tcs in _pendingRequests.Values)
+            {
+                tcs.TrySetCanceled();
+            }
+            _pendingRequests.Clear();
+        }
+    }
+
+    private static string BuildCacheKey(string prompt, string instructionId)
+    {
+        var normalizedPrompt = NormalizePrompt(prompt);
+        return string.IsNullOrEmpty(instructionId)
+            ? normalizedPrompt
+            : $"{normalizedPrompt}||{instructionId.ToLowerInvariant()}";
+    }
+
+    private static string NormalizePrompt(string prompt)
+    {
+        return string.IsNullOrWhiteSpace(prompt)
+            ? string.Empty
+            : new string(prompt.Trim().ToLowerInvariant().Where(c => !char.IsWhiteSpace(c)).ToArray());
+    }
+
+    private bool TryGetFromCacheLocked(string key, out string cachedResult)
+    {
+        if (!_cache.TryGetValue(key, out cachedResult))
+        {
+            return false;
+        }
+
+        Logs.Debug("MagicPromptExtension.PromptCache: cache hit");
+        if (_cacheNodes.TryGetValue(key, out var node))
+        {
+            _accessOrder.Remove(node);
+            _accessOrder.AddLast(node);
+        }
+        return true;
+    }
+
+    private void AddToCacheLocked(string key, string value)
+    {
+        while (_cache.Count >= _maxSize)
+        {
+            var oldestNode = _accessOrder.First;
+            if (oldestNode != null)
+            {
+                var oldestKey = oldestNode.Value;
+                _cache.Remove(oldestKey);
+                _cacheNodes.Remove(oldestKey);
+                _accessOrder.RemoveFirst();
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        _cache[key] = value;
+
+        if (_cacheNodes.TryGetValue(key, out var existingNode))
+        {
+            _accessOrder.Remove(existingNode);
+        }
+
+        var newNode = _accessOrder.AddLast(key);
+        _cacheNodes[key] = newNode;
+    }
+
+    private void SignalPendingRequestLocked(string key, string result)
+    {
+        if (_pendingRequests.TryGetValue(key, out var tcs))
+        {
+            tcs.TrySetResult(result ?? string.Empty);
+        }
+    }
+
+    private void CleanupPendingRequestLocked(string key)
+    {
+        _pendingRequests.Remove(key);
+    }
+
+    private static string WaitForPendingRequest(TaskCompletionSource<string> tcs, int timeoutMs)
+    {
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+        try
+        {
+            if (!tcs.Task.Wait(timeoutMs))
+            {
+                Logs.Warning($"MagicPromptExtension.PromptCache: timeout after {timeoutMs}ms waiting for pending request");
+                return null;
+            }
+
+            stopwatch.Stop();
+            var result = tcs.Task.Result;
+
+            if (string.IsNullOrEmpty(result))
+            {
+                Logs.Debug("MagicPromptExtension.PromptCache: waited for owner request, but got empty result");
+                return null;
+            }
+
+            Logs.Debug($"MagicPromptExtension.PromptCache: waited {stopwatch.ElapsedMilliseconds}ms for owner request");
+            return result;
+        }
+        catch (OperationCanceledException)
+        {
+            Logs.Debug("MagicPromptExtension.PromptCache: pending request was cancelled");
+            return null;
+        }
+        catch (AggregateException ex) when (ex.InnerException is OperationCanceledException)
+        {
+            Logs.Debug("MagicPromptExtension.PromptCache: pending request was cancelled");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            Logs.Error($"MagicPromptExtension.PromptCache: error waiting for pending request: {ex.Message}");
+            return null;
+        }
+    }
+}

--- a/PromptHandler.cs
+++ b/PromptHandler.cs
@@ -1,0 +1,194 @@
+using System.Text.RegularExpressions;
+using Hartsy.Extensions.MagicPromptExtension.WebAPI;
+using Newtonsoft.Json.Linq;
+using SwarmUI.Text2Image;
+using SwarmUI.Utils;
+
+namespace Hartsy.Extensions.MagicPromptExtension;
+
+public class PromptHandler
+{
+    // Matches <mpprompt:...> and <mpprompt[InstructionName]:...>
+    // Group 1 = instruction identifier (optional), Group 2 = prompt content (handles nested tags)
+    private static readonly Regex MppromptRegex = new(@"<mpprompt(?:\[([^\]]+)\])?:((?:[^<>]|<[^>]*>)+)>", RegexOptions.Compiled);
+    private static readonly Regex MpresponseRegex = new(@"<mpresponse:(\d+)>", RegexOptions.Compiled);
+    private readonly PromptCache _cache;
+    private readonly T2IRegisteredParam<bool> _paramUseCache;
+    private readonly T2IRegisteredParam<string> _paramModelId;
+    private readonly T2IRegisteredParam<string> _paramInstructions;
+
+    public PromptHandler(
+        PromptCache cache,
+        T2IRegisteredParam<bool> paramUseCache,
+        T2IRegisteredParam<string> paramModelId,
+        T2IRegisteredParam<string> paramInstructions)
+    {
+        _cache = cache;
+        _paramUseCache = paramUseCache;
+        _paramModelId = paramModelId;
+        _paramInstructions = paramInstructions;
+    }
+
+    /// <summary>
+    /// Processes a prompt, handling all mpprompt tags by calling the LLM and replacing them with responses.
+    /// </summary>
+    public void ProcessPrompt(T2IParamInput userInput)
+    {
+        var prompt = userInput.Get(T2IParamTypes.Prompt);
+        var modelId = userInput.Get(_paramModelId);
+        var useCache = userInput.Get(_paramUseCache);
+
+        var matches = MppromptRegex.Matches(prompt);
+
+        if (matches.Count == 0)
+        {
+            prompt = CleanOrphanedMpresponse(prompt);
+            FinalizePrompt(prompt, "", userInput);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(modelId))
+        {
+            prompt = StripMppromptTags(prompt);
+            prompt = StripMpresponseTags(prompt);
+            FinalizePrompt(prompt, "", userInput);
+            return;
+        }
+
+        if (!useCache)
+        {
+            _cache.Clear();
+        }
+
+        var firstMppromptContent = matches[0].Groups[2].Value;
+        var llmResponses = new List<string>();
+
+        for (int i = 0; i < matches.Count; i++)
+        {
+            var match = matches[i];
+            var fullTag = match.Value;
+            var instructionId = match.Groups[1].Success ? match.Groups[1].Value : null;
+            var mppromptContent = ResolveMpresponseReferences(match.Groups[2].Value, llmResponses);
+
+            var llmResponse = GetLlmResponse(mppromptContent, userInput, instructionId, useCache, i, fullTag);
+            llmResponses.Add(llmResponse);
+            prompt = prompt.Replace(fullTag, llmResponse);
+        }
+
+        prompt = ResolveMpresponseReferences(prompt, llmResponses, logStandalone: true);
+        FinalizePrompt(prompt, firstMppromptContent, userInput);
+    }
+
+    private string GetLlmResponse(string content, T2IParamInput userInput, string instructionId, bool useCache, int tagIndex, string fullTag)
+    {
+        try
+        {
+            string response;
+            if (useCache)
+            {
+                var timeoutMs = LLMAPICalls.GetChatBackendTimeoutMs();
+                response = _cache.GetOrCreate(content, instructionId, () => MakeLlmRequest(content, userInput, instructionId), timeoutMs);
+            }
+            else
+            {
+                response = MakeLlmRequest(content, userInput, instructionId);
+            }
+
+            if (string.IsNullOrEmpty(response))
+            {
+                Logs.Error($"MagicPromptExtension.PromptHandler: empty response from LLM for tag #{tagIndex}: {fullTag}");
+                return content; // Fall back to original content
+            }
+
+            return response;
+        }
+        catch (Exception ex)
+        {
+            Logs.Error($"MagicPromptExtension.PromptHandler: LLM call failed for tag #{tagIndex} '{fullTag}': {ex.Message}");
+            return content; // Fall back to original content
+        }
+    }
+
+    private string MakeLlmRequest(string prompt, T2IParamInput userInput, string instructionId = null)
+    {
+        var request = new JObject
+        {
+            ["messageContent"] = new JObject
+            {
+                ["text"] = prompt,
+                ["instructions"] = InstructionResolver.Resolve(userInput, instructionId, _paramInstructions)
+            },
+            ["modelId"] = userInput.Get(_paramModelId, defVal: string.Empty),
+            ["messageType"] = "Text",
+            ["action"] = "prompt",
+            ["session_id"] = userInput.SourceSession?.ID ?? string.Empty,
+            ["seed"] = userInput.Get(T2IParamTypes.Seed, -1).ToString()
+        };
+
+        var resp = LLMAPICalls.MagicPromptPhoneHome(request, userInput.SourceSession)
+            .GetAwaiter()
+            .GetResult();
+
+        var success = resp?["success"];
+        if (success == null || !success.Value<bool>())
+        {
+            return null;
+        }
+
+        var llmResponse = resp?["response"]?.ToString();
+        return string.IsNullOrWhiteSpace(llmResponse) ? null : llmResponse;
+    }
+
+    /// <summary>
+    /// Resolves mpresponse references within text, substituting with previously obtained LLM responses.
+    /// </summary>
+    private static string ResolveMpresponseReferences(string text, List<string> llmResponses, bool logStandalone = false)
+    {
+        return MpresponseRegex.Replace(text, m =>
+        {
+            if (!int.TryParse(m.Groups[1].Value, out int refIndex))
+            {
+                return m.Value;
+            }
+
+            if (refIndex >= 0 && refIndex < llmResponses.Count)
+            {
+                return llmResponses[refIndex];
+            }
+
+            if (logStandalone)
+            {
+                Logs.Warning($"MagicPromptExtension.PromptHandler: <mpresponse:{refIndex}> references invalid index (only {llmResponses.Count} responses available)");
+                return "";
+            }
+
+            Logs.Error($"MagicPromptExtension.PromptHandler: <mpresponse:{refIndex}> references future mpprompt (only {llmResponses.Count} responses available)");
+            return $"[ERROR: mpresponse:{refIndex} not yet available]";
+        });
+    }
+
+    private static string CleanOrphanedMpresponse(string prompt)
+    {
+        if (MpresponseRegex.IsMatch(prompt))
+        {
+            Logs.Warning("MagicPromptExtension.PromptHandler: <mpresponse> found but no mpprompt tags exist");
+            return MpresponseRegex.Replace(prompt, "");
+        }
+        return prompt;
+    }
+
+    private static string StripMppromptTags(string prompt)
+    {
+        return MppromptRegex.Replace(prompt, m => m.Groups[2].Value);
+    }
+
+    private static string StripMpresponseTags(string prompt)
+    {
+        return MpresponseRegex.Replace(prompt, "");
+    }
+
+    private static void FinalizePrompt(string prompt, string originalMpprompt, T2IParamInput userInput)
+    {
+        userInput.Set(T2IParamTypes.Prompt, prompt.Replace("<mporiginal>", originalMpprompt));
+    }
+}

--- a/WebAPI/LLMAPICalls.cs
+++ b/WebAPI/LLMAPICalls.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using Hartsy.Extensions.MagicPromptExtension.WebAPI.Models;
 
 using static Hartsy.Extensions.MagicPromptExtension.BackendSchema;
+using SwarmUI.Backends;
 
 namespace Hartsy.Extensions.MagicPromptExtension.WebAPI;
 


### PR DESCRIPTION
This PR pretty much focuses on splitting up the rather large `MagicPromptExtension.cs` into smaller files that focus on specific tasks.

This will allow me to start writing a unit test suite for the extension.