### PR TITLE
Throw on LLM errors instead of fallback

### DIFF
--- a/PromptCache.cs
+++ b/PromptCache.cs
@@ -67,10 +67,15 @@ public class PromptCache
 
             lock (_lock)
             {
+                // Signal waiting threads with the error so they don't hang until timeout
+                if (_pendingRequests.TryGetValue(cacheKey, out var tcs))
+                {
+                    tcs.TrySetException(ex);
+                }
                 CleanupPendingRequestLocked(cacheKey);
             }
 
-            return null;
+            throw; // Re-throw so GetLlmResponse can convert to SwarmReadableErrorException
         }
 
         lock (_lock)
@@ -209,6 +214,11 @@ public class PromptCache
         {
             Logs.Debug("MagicPromptExtension.PromptCache: pending request was cancelled");
             return null;
+        }
+        catch (AggregateException ex) when (ex.InnerException is not OperationCanceledException)
+        {
+            Logs.Error($"MagicPromptExtension.PromptCache: pending request failed: {ex.InnerException.Message}");
+            throw ex.InnerException; // Re-throw the factory error so it propagates to the caller
         }
         catch (Exception ex)
         {

--- a/PromptHandler.cs
+++ b/PromptHandler.cs
@@ -97,7 +97,7 @@ public class PromptHandler
             if (string.IsNullOrEmpty(response))
             {
                 Logs.Error($"MagicPromptExtension.PromptHandler: empty response from LLM for tag #{tagIndex}: {fullTag}");
-                return content; // Fall back to original content
+                return content; // Fall back to original content for empty (non-error) responses
             }
 
             return response;
@@ -105,7 +105,7 @@ public class PromptHandler
         catch (Exception ex)
         {
             Logs.Error($"MagicPromptExtension.PromptHandler: LLM call failed for tag #{tagIndex} '{fullTag}': {ex.Message}");
-            return content; // Fall back to original content
+            throw new SwarmReadableErrorException($"[MagicPrompt] LLM request failed: {ex.Message}");
         }
     }
 
@@ -132,7 +132,8 @@ public class PromptHandler
         var success = resp?["success"];
         if (success == null || !success.Value<bool>())
         {
-            return null;
+            var errorMsg = resp?["error"]?.ToString() ?? "Unknown LLM error";
+            throw new InvalidOperationException(errorMsg);
         }
 
         var llmResponse = resp?["response"]?.ToString();


### PR DESCRIPTION
Change PromptHandler error handling to surface LLM failures instead of silently falling back to the original content. Empty (non-error) responses still return the original content, but exceptions from the LLM call now throw a SwarmReadableErrorException with a readable message. When the LLM response indicates success==false, the code now throws an InvalidOperationException containing the LLM-provided error or a default message instead of returning null.