### PR TITLE
Fix error handler

### DIFF
--- a/WebAPI/ErrorHandler.cs
+++ b/WebAPI/ErrorHandler.cs
@@ -915,13 +915,16 @@ public class ErrorHandlerImplementation : IErrorHandler
                     {
                         return errorToken.ToString();
                     }
-                    if (errorToken["message"] != null)
+                    if (errorToken is JObject errObj)
                     {
-                        return errorToken["message"].ToString();
-                    }
-                    if (errorToken["error"]?["message"] != null)
-                    {
-                        return errorToken["error"]["message"].ToString();
+                        if (errObj["message"] != null)
+                        {
+                            return errObj["message"].ToString();
+                        }
+                        if (errObj["error"]?["message"] != null)
+                        {
+                            return errObj["error"]["message"].ToString();
+                        }
                     }
                 }
                 if (jobj["message"] != null)

--- a/WebAPI/ErrorHandler.cs
+++ b/WebAPI/ErrorHandler.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using Hartsy.Extensions.MagicPromptExtension.WebAPI.Models;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using SwarmUI.Utils;
 
 namespace Hartsy.Extensions.MagicPromptExtension.WebAPI;
@@ -819,14 +820,15 @@ public class ErrorHandlerImplementation : IErrorHandler
                 return false;
             }
             errorMessage = error;
-            // Map Ollama errors based on known patterns without string checks
-            if (statusCode == HttpStatusCode.NotFound)
+            if (statusCode == HttpStatusCode.NotFound ||
+                error.Contains("no longer compatible", StringComparison.OrdinalIgnoreCase) ||
+                error.Contains("ollama pull", StringComparison.OrdinalIgnoreCase) ||
+                error.Contains("not found", StringComparison.OrdinalIgnoreCase))
             {
                 errorType = ErrorType.ModelNotFound;
             }
             else
             {
-                // Use HTTP status code as a fallback
                 errorType = MapStatusCodeToErrorType(statusCode, "ollama");
             }
             Logs.Error($"Ollama error: {error} (HTTP {(int)statusCode})");
@@ -904,24 +906,27 @@ public class ErrorHandlerImplementation : IErrorHandler
         try
         {
             dynamic json = JsonConvert.DeserializeObject<dynamic>(responseContent);
-            if (json != null)
+            if (json is JObject jobj)
             {
-                // Try common error message paths
-                if (json.error?.message != null)
+                JToken errorToken = jobj["error"];
+                if (errorToken != null)
                 {
-                    return json.error.message.ToString();
+                    if (errorToken.Type == JTokenType.String)
+                    {
+                        return errorToken.ToString();
+                    }
+                    if (errorToken["message"] != null)
+                    {
+                        return errorToken["message"].ToString();
+                    }
+                    if (errorToken["error"]?["message"] != null)
+                    {
+                        return errorToken["error"]["message"].ToString();
+                    }
                 }
-                else if (json.error?.error?.message != null)
+                if (jobj["message"] != null)
                 {
-                    return json.error.error.message.ToString();
-                }
-                else if (json.message != null)
-                {
-                    return json.message.ToString();
-                }
-                else if (json.error != null && json.error is string)
-                {
-                    return json.error.ToString();
+                    return jobj["message"].ToString();
                 }
             }
         }


### PR DESCRIPTION
# Bug Fix: Ollama Error Handling in `ErrorHandler.cs`

### 1. `ExtractOriginalMessage` throws on Ollama-style error responses

Ollama returns errors as a flat JSON string:

```json
{"error": "some error message"}
```

`ExtractOriginalMessage` deserialized the response to `dynamic` then accessed `json.error?.message`. When `error` is a plain string, Newtonsoft's dynamic `JValue` throws on the `.message` property access, landing in the catch block and logging `"Failed to extract message from: ..."` instead of returning the actual error text. The `json.error is string` branch below it was never reached because the exception was already thrown.

**Fix:** Switched from `dynamic` property chains to direct `JObject`/`JToken` access, checking `errorToken.Type == JTokenType.String` before trying to treat it as an object.

### 2. Ollama model compatibility errors misclassified as `ServerError`

When Ollama returns HTTP 500 because a model manifest is outdated (e.g. `"'llama3.2-vision' is no longer compatible with your version of Ollama"`), `TryParseOllamaError` fell back to `MapStatusCodeToErrorType(500, "ollama")` which maps to `ErrorType.ServerError`. This showed the generic *"Ollama Server Error: try restarting Ollama"* template, which is unhelpful and misleading; the actual fix is `ollama pull <model>`.

**Fix:** Added text-based detection in `TryParseOllamaError`. If the error message contains `"no longer compatible"`, `"ollama pull"`, or `"not found"`, the error is classified as `ModelNotFound` regardless of HTTP status code. The `ModelNotFound` template already gives the correct instruction to re-pull the
model.

## Affected File

`WebAPI/ErrorHandler.cs`

## Reproduction

1. Install Ollama and pull an older version of `llama3.2-vision`.
2. Upgrade Ollama without re-pulling the model.
3. Trigger a MagicPrompt request using that model.
4. Observe logs:
   - `Failed to extract message from: {"error":"..."}` (bug 1)
   - `Ollama Server Error` template shown to user instead of model pull instructions (bug 2)

## Expected Behavior

- No `"Failed to extract message from"` log for valid Ollama error responses.
- User sees the *Ollama Model Not Found* message with instructions to run `ollama pull llama3.2-vision`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of model-related errors and compatibility issues
  * Enhanced error message extraction to handle multiple error response formats reliably

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HartsyAI/SwarmUI-MagicPromptExtension/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->