### PR TITLE
feat: add configurable max tokens support

### DIFF
--- a/Assets/settings.js
+++ b/Assets/settings.js
@@ -9,6 +9,9 @@
 // Define backends that don't need base URL configuration
 const FIXED_URL_BACKENDS = ['openai', 'anthropic', 'openrouter', 'grok'];
 
+// Define the default max token limit for requests
+const DEFAULT_MAX_TOKENS = 1024;
+
 // Define default feature to instruction mappings
 const DEFAULT_FEATURE_MAPPINGS = {
   'enhance-prompt': 'prompt',
@@ -74,6 +77,7 @@ async function loadSettings() {
               serverSettings.backend ||
               'ollama',
             visionmodel: serverSettings.visionmodel || '',
+            max_tokens: Number(serverSettings.max_tokens) || DEFAULT_MAX_TOKENS,
             linkChatAndVisionModels:
               serverSettings.linkChatAndVisionModels !== false, // Default to true if not set
             // Backends - merge using spread operator which does a "deep merge" of two objects
@@ -190,6 +194,7 @@ async function saveSettings(skipFeatureMappings = false) {
     const visionTimeout = isLinked
       ? chatTimeout
       : parseInt(document.getElementById('visionTimeout')?.value, 10);
+    const maxTokens = parseInt(document.getElementById('maxTokens')?.value, 10);
     // Create settings object matching exact structure expected by C# DefaultSettings
     const settings = {
       // Core settings
@@ -197,6 +202,7 @@ async function saveSettings(skipFeatureMappings = false) {
       model: chatModel,
       visionbackend: visionBackendId,
       visionmodel: visionModel,
+      max_tokens: !isNaN(maxTokens) && maxTokens > 0 ? maxTokens : MP.settings.max_tokens,
       linkChatAndVisionModels: isLinked,
       backends: {
         ...MP.settings.backends,
@@ -1820,6 +1826,10 @@ function initSettingsModal() {
     if (chatTimeoutInput) {
       const defaultChatTimeout = currentBackend === 'ollama' || currentBackend === 'openaiapi' ? 120 : 60;
       chatTimeoutInput.value = MP.settings.backends[currentBackend]?.timeout ?? defaultChatTimeout;
+    }
+    const maxTokensInput = document.getElementById('maxTokens');
+    if (maxTokensInput) {
+      maxTokensInput.value = MP.settings.max_tokens ?? DEFAULT_MAX_TOKENS;
     }
     const currentVisionBackend = MP.settings.visionbackend || 'ollama';
     const currentVisionBackendRadio = document.getElementById(

--- a/BackendSchema.cs
+++ b/BackendSchema.cs
@@ -10,6 +10,8 @@ namespace Hartsy.Extensions.MagicPromptExtension;
 
 public static class BackendSchema
 {
+    public static readonly int DefaultMaxTokens = 1024;
+
     public enum MessageType
     {
         Text,
@@ -37,7 +39,7 @@ public static class BackendSchema
     /// <param name="model">Model name to use</param>
     /// <param name="messageType">Type of message (Text or Vision)</param>
     /// <returns>Returns an object with the schema type for the backend.</returns>
-    public static object GetSchemaType(string type, MessageContent content, string model, MessageType messageType = MessageType.Text, long seed = -1)
+    public static object GetSchemaType(string type, MessageContent content, string model, MessageType messageType = MessageType.Text, long seed = -1, int? maxTokens = null)
     {
         if (content == null || string.IsNullOrEmpty(model))
         {
@@ -48,9 +50,9 @@ public static class BackendSchema
         return type switch
         {
             "ollama" => OllamaRequestBody(content, model, messageType, seed),
-            "grok" => OpenAICompatibleRequestBody(content, model, messageType, preferPngForBase64: true, seed),
-            "openai" or "openaiapi" or "openrouter" => OpenAICompatibleRequestBody(content, model, messageType, preferPngForBase64: false, seed),
-            "anthropic" => AnthropicRequestBody(content, model, messageType),
+            "grok" => OpenAICompatibleRequestBody(content, model, messageType, preferPngForBase64: true, seed, maxTokens),
+            "openai" or "openaiapi" or "openrouter" => OpenAICompatibleRequestBody(content, model, messageType, preferPngForBase64: false, seed, maxTokens),
+            "anthropic" => AnthropicRequestBody(content, model, messageType, maxTokens),
             _ => throw new ArgumentException($"Unsupported backend type: {type}")
         };
     }
@@ -139,7 +141,7 @@ public static class BackendSchema
     }
 
     /// <summary>Generates a request body for OpenAI and compatible backends.</summary>
-    private static object OpenAICompatibleRequestBody(MessageContent content, string model, MessageType messageType, bool preferPngForBase64, long seed = -1)
+    private static object OpenAICompatibleRequestBody(MessageContent content, string model, MessageType messageType, bool preferPngForBase64, long seed = -1, int? maxTokens = null)
     {
         List<object> messages = [];
         // Add system message if instructions exist
@@ -178,7 +180,7 @@ public static class BackendSchema
                 {
                     model,
                     messages = messages.ToArray(),
-                    max_tokens = 1000,
+                    max_tokens = maxTokens ?? DefaultMaxTokens,
                     temperature = 1.0,
                     stream = false,
                     seed
@@ -189,7 +191,7 @@ public static class BackendSchema
             {
                 model,
                 messages = messages.ToArray(),
-                max_tokens = 1000,
+                max_tokens = maxTokens ?? DefaultMaxTokens,
                 temperature = 1.0,
                 stream = false
             };
@@ -202,7 +204,7 @@ public static class BackendSchema
             {
                 model,
                 messages = messages.ToArray(),
-                max_tokens = 1000,
+                max_tokens = maxTokens ?? DefaultMaxTokens,
                 temperature = 1.0,
                 stream = false,
                 seed
@@ -214,14 +216,14 @@ public static class BackendSchema
             model,
             messages = messages.ToArray(),
             temperature = 1.0,
-            max_tokens = 1000,
+            max_tokens = maxTokens ?? DefaultMaxTokens,
             top_p = 0.9,
             stream = false
         };
     }
 
     /// <summary>Generates a request body for the Anthropic (Claude) API.</summary>
-    private static object AnthropicRequestBody(MessageContent content, string model, MessageType messageType)
+    private static object AnthropicRequestBody(MessageContent content, string model, MessageType messageType, int? maxTokens = null)
     {
         List<object> messages = [];
         if (messageType == MessageType.Vision && content.Media?.Any() == true)
@@ -258,7 +260,7 @@ public static class BackendSchema
                 model,
                 messages = messages.ToArray(),
                 system = content.Instructions,
-                max_tokens = 1024
+                max_tokens = maxTokens ?? DefaultMaxTokens
             };
         }
         messages.Add(new { role = "user", content = content.Text });
@@ -267,7 +269,7 @@ public static class BackendSchema
             model,
             messages = messages.ToArray(),
             system = content.Instructions,
-            max_tokens = 1024
+            max_tokens = maxTokens ?? DefaultMaxTokens
         };
     }
 }

--- a/Tabs/Text2Image/MagicPrompt.html
+++ b/Tabs/Text2Image/MagicPrompt.html
@@ -181,7 +181,7 @@
                                             <label class="btn btn-outline-primary" for="grokLLMBtn">Grok (xAI)</label>
                                         </div>
                                     </div>
-                                    <div class="d-flex gap-3">
+                                    <div class="d-flex gap-3 flex-wrap">
                                         <div class="form-group flex-grow-1" id="baseUrlContainer">
                                             <label class="form-label">Base URL</label>
                                             <input type="text" class="form-control" id="backendUrl" placeholder="Enter base URL">
@@ -189,6 +189,10 @@
                                         <div class="form-group" id="chatTimeoutContainer" style="min-width: 120px;">
                                             <label class="form-label">Timeout (s)</label>
                                             <input type="number" class="form-control" id="chatTimeout" min="0" step="1" placeholder="seconds">
+                                        </div>
+                                        <div class="form-group" id="chatMaxTokensContainer" style="min-width: 140px;">
+                                            <label class="form-label">Max Tokens</label>
+                                            <input type="number" class="form-control" id="maxTokens" min="1" step="1" placeholder="tokens">
                                         </div>
                                     </div>
                                     <div class="form-group">

--- a/WebAPI/LLMAPICalls.cs
+++ b/WebAPI/LLMAPICalls.cs
@@ -544,7 +544,13 @@ public class LLMAPICalls : MagicPromptAPI
             object requestBody;
             try
             {
-                int maxTokens = settings["max_tokens"]?.Value<int?>() ?? BackendSchema.DefaultMaxTokens;
+                int maxTokens = BackendSchema.DefaultMaxTokens;
+                if (long.TryParse(settings["max_tokens"]?.ToString(), out long parsedMaxTokens)
+                    && parsedMaxTokens >= 1
+                    && parsedMaxTokens <= int.MaxValue)
+                {
+                    maxTokens = (int)parsedMaxTokens;
+                }
                 requestBody = GetSchemaType(backend, messageContent, modelId, messageType, seed, maxTokens);
             }
             catch (ArgumentException ex)

--- a/WebAPI/LLMAPICalls.cs
+++ b/WebAPI/LLMAPICalls.cs
@@ -544,7 +544,8 @@ public class LLMAPICalls : MagicPromptAPI
             object requestBody;
             try
             {
-                requestBody = GetSchemaType(backend, messageContent, modelId, messageType, seed);
+                int maxTokens = settings["max_tokens"]?.Value<int?>() ?? BackendSchema.DefaultMaxTokens;
+                requestBody = GetSchemaType(backend, messageContent, modelId, messageType, seed, maxTokens);
             }
             catch (ArgumentException ex)
             {

--- a/WebAPI/SessionSettings.cs
+++ b/WebAPI/SessionSettings.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json.Linq;
+using SwarmUI.Backends;
 using SwarmUI.Core;
 using SwarmUI.Utils;
 
@@ -82,6 +83,7 @@ public class SessionSettings : MagicPromptAPI
         ["visionbackend"] = "ollama",
         ["model"] = "llama3.2-vision:latest",
         ["visionmodel"] = "llama3.2-vision:latest",
+        ["max_tokens"] = BackendSchema.DefaultMaxTokens,
         ["instructions"] = new JObject
         {
             ["chat"] = "You are a chatbot named Hartsy. Come up with a random backstory as to why you were created and how you were made to help the user with Stable Diffusion. You will respond to any questions or chats in this character. You will include tips on how to make good prompts for stable diffusion. Never break character and randomly end your response with \"Thank you for choosing Hartsy!\"",


### PR DESCRIPTION
Running the extension against newer (thinking) models, like Gemma4, produces trimmed responses with the stop reason "length". This is because the thinking models generate "thinking" tokens which are counted to the actual prompt response. To workaround this, `max_tokens` parameter can now be configured via settings dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable "Max Tokens" setting for Chat LLM requests with a default limit of 1024 tokens
  * Added "Max Tokens" numeric input field to Chat LLM settings panel for easy customization
  * Token limit settings now persist across sessions and apply to all supported AI backends

<!-- end of auto-generated comment: release notes by coderabbit.ai -->